### PR TITLE
modify freetype include path compatible with openframeworks 0.9.0

### DIFF
--- a/src/ofxTrueTypeFontUC.cpp
+++ b/src/ofxTrueTypeFontUC.cpp
@@ -10,10 +10,10 @@
 #include FT_TRIGONOMETRY_H
 #include <fontconfig/fontconfig.h>
 #else
-#include "freetype2/freetype/freetype.h"
-#include "freetype2/freetype/ftglyph.h"
-#include "freetype2/freetype/ftoutln.h"
-#include "freetype2/freetype/fttrigon.h"
+#include "freetype.h"
+#include "ftglyph.h"
+#include "ftoutln.h"
+#include "fttrigon.h"
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
i try to use this addon in the latest release openframeworks 0.9.0 and found some issue about include path.

Since, freetype include path was change in the latest openframeworks release, I just simply modify the path.

Please see the forum suggest for the solution.
https://forum.openframeworks.cc/t/missing-of-lib-include-files/14326

Kind Regards,