### PR TITLE
Improve compatibility for openFrameworks 0.9.2 and up

### DIFF
--- a/src/ofxTrueTypeFontUC.cpp
+++ b/src/ofxTrueTypeFontUC.cpp
@@ -626,6 +626,10 @@ void ofxTrueTypeFontUC::reloadFont() {
 }
 
 //-----------------------------------------------------------
+bool ofxTrueTypeFontUC::load(string filename, int fontsize, bool bAntiAliased, bool makeContours, float simplifyAmt, int dpi) {
+  return loadFont(filename, fontsize, bAntiAliased, makeContours, simplifyAmt, dpi);
+}
+
 bool ofxTrueTypeFontUC::loadFont(string filename, int fontsize, bool bAntiAliased, bool makeContours, float simplifyAmt, int dpi) {
   return mImpl->implLoadFont(filename, fontsize, bAntiAliased, makeContours, simplifyAmt, dpi);
   

--- a/src/ofxTrueTypeFontUC.cpp
+++ b/src/ofxTrueTypeFontUC.cpp
@@ -1289,7 +1289,11 @@ void ofxTrueTypeFontUC::Impl::loadChar(const int &charID) {
   else {
     textures[i].setTextureMinMagFilter(GL_NEAREST,GL_NEAREST);
   }
-  
-  textures[i].loadData(atlasPixels.getPixels(), atlasPixels.getWidth(), atlasPixels.getHeight(), GL_LUMINANCE_ALPHA);
+	
+  #if (OF_VERSION_MAJOR == 0 && OF_VERSION_MINOR >= 9 && OF_VERSION_PATCH >= 2) || OF_VERSION_MAJOR > 0
+	textures[i].loadData(atlasPixels.getData(), atlasPixels.getWidth(), atlasPixels.getHeight(), GL_LUMINANCE_ALPHA);
+  #else
+	textures[i].loadData(atlasPixels.getPixels(), atlasPixels.getWidth(), atlasPixels.getHeight(), GL_LUMINANCE_ALPHA);
+  #endif
 }
 

--- a/src/ofxTrueTypeFontUC.h
+++ b/src/ofxTrueTypeFontUC.h
@@ -21,6 +21,7 @@ public:
   static void setGlobalDpi(int newDpi);
   
   // 			-- default (without dpi), anti aliased, 96 dpi:
+  bool load(string filename, int fontsize, bool bAntiAliased=true, bool makeContours=false, float simplifyAmt=0.3, int dpi=0);
   bool loadFont(string filename, int fontsize, bool bAntiAliased=true, bool makeContours=false, float simplifyAmt=0.3, int dpi=0);
   void reloadFont();
   void unloadFont();


### PR DESCRIPTION
`ofTrueTypeFont` uses `load()` instead of `loadFont()` now. Replaced `getPixels()` with `getData()` as `getPixels()` is deprecated in oF 0.9.2 and will be removed in next version.